### PR TITLE
Change viewPort's edge color in the minimap according to the mode

### DIFF
--- a/argo-lite/src/graph-frontend/src/api.js
+++ b/argo-lite/src/graph-frontend/src/api.js
@@ -216,7 +216,12 @@ module.exports = function(self) {
 
   self.toggleDark = function() {
     self.darkMode = !self.darkMode;
+    self.updateViewPortEdgeColor();
   };
+
+  self.updateViewPortEdgeColor = function() {
+    self.viewPort.material.color = new THREE.Color( self.darkMode? 0xffffff : 0x000000 );       
+  }
 
   self.getGraph = function() {
     return self.graph;

--- a/argo-lite/src/graph-frontend/src/setup.js
+++ b/argo-lite/src/graph-frontend/src/setup.js
@@ -239,7 +239,7 @@ module.exports = function(self) {
   self.setupViewPort = function(rect) {
     self.viewPort = new THREE.Line(
       rect,
-      new THREE.LineBasicMaterial({ linewidth: 3, color: 0x333333 })
+      new THREE.LineBasicMaterial({ linewidth: 3, color: self.darkMode? 0xffffff : 0x000000})
     );
     self.scene.add(self.viewPort);
     self.setViewPortSize(self.ccamera);


### PR DESCRIPTION
This improves the visibility of viewPort in the minimap. The rectangle will change edge color according to the mode (White when it's in dark mode, Black when it's not). 