### PR TITLE
Performance Improvements

### DIFF
--- a/argo-lite/package-lock.json
+++ b/argo-lite/package-lock.json
@@ -12857,6 +12857,11 @@
         }
       }
     },
+    "stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha1-scPcRtlEmLV4t/05hbgaznExzH0="
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",

--- a/argo-lite/package.json
+++ b/argo-lite/package.json
@@ -85,6 +85,7 @@
     "resolve-url-loader": "3.1.0",
     "sass-loader": "7.2.0",
     "semver": "6.3.0",
+    "stats.js": "^0.17.0",
     "style-loader": "1.0.0",
     "terser-webpack-plugin": "1.4.1",
     "threads": "^0.10.1",

--- a/argo-lite/src/components/ImportDialog.jsx
+++ b/argo-lite/src/components/ImportDialog.jsx
@@ -245,6 +245,10 @@ class ImportDialog extends React.Component {
                     requestImportGraphFromCSV( //edgefile.delimiter and nodefile.delimiter are the same
                       this.state.available === NODE_AND_EDGE_FILE, appState.import.importConfig.edgeFile.delimiter, appState.project.newProjectName
                     );
+
+                    // Importing a graph means no label would be shown by default,
+                    // thus turn off label CSSRenderer for better performance.
+                    appState.graph.frame.turnOffLabelCSSRenderer();
                   }}
                   text="Import"
                 />

--- a/argo-lite/src/graph-frontend/include/CSS3DRenderer.js
+++ b/argo-lite/src/graph-frontend/include/CSS3DRenderer.js
@@ -67,6 +67,9 @@ THREE.CSS3DRenderer = function() {
 
   this.setClearColor = function() {};
 
+  // Added by Argo-lite, for optimization
+  this.isPaused = false;
+
   this.getSize = function() {
     return {
       width: _width,
@@ -211,6 +214,9 @@ THREE.CSS3DRenderer = function() {
   }
 
   this.render = function(scene, camera) {
+    if (this.isPaused) {
+      return;
+    }
     var fov =
       (0.5 / Math.tan(THREE.Math.degToRad(camera.getEffectiveFOV() * 0.5))) *
       _height;

--- a/argo-lite/src/graph-frontend/src/api.js
+++ b/argo-lite/src/graph-frontend/src/api.js
@@ -77,12 +77,18 @@ module.exports = function(self) {
   // default and only use it when no node is moving to prevent
   // visible lagging (during layout, dragging etc.)
   self.turnOffLabelCSSRenderer = () => {
+    if (self.cssRenderer.isPaused) {
+      return;
+    }
     self.element.removeChild(self.cssRenderer.domElement);
     self.cssRenderer.isPaused = true;
   };
 
   // See turnOffLabelCSSRenderer.
   self.turnOnLabelCSSRenderer = () => {
+    if (!self.cssRenderer.isPaused) {
+      return;
+    }
     self.element.appendChild(self.cssRenderer.domElement);
     self.cssRenderer.isPaused = false;
   };

--- a/argo-lite/src/graph-frontend/src/imports.js
+++ b/argo-lite/src/graph-frontend/src/imports.js
@@ -39,6 +39,7 @@ exports.default = {
   LAYOUT: "d3",
   LINES: "notfancy",
   MAP: true,
+  MAP_RENDER_PER_NUMBER_OF_FRAME: 20,
   TEXT_SCALE: true,
   TEXT_SIZE: 0.07,
   TEXT_X_OFFSET: 0.52,

--- a/argo-lite/src/graph-frontend/src/imports.js
+++ b/argo-lite/src/graph-frontend/src/imports.js
@@ -15,7 +15,7 @@ var ee = require("event-emitter");
 exports.default = {
   THREE: THREE,
   STATS: STATS, // stats.js panel for showing fps and other stats.
-  STATS_SHOW: true,
+  STATS_SHOW: false,
   Edge: Edge,
   Node: Node,
   OrbitControls: OrbitControls,

--- a/argo-lite/src/graph-frontend/src/imports.js
+++ b/argo-lite/src/graph-frontend/src/imports.js
@@ -15,7 +15,7 @@ var ee = require("event-emitter");
 exports.default = {
   THREE: THREE,
   STATS: STATS, // stats.js panel for showing fps and other stats.
-  STATS_SHOW: false,
+  STATS_SHOW: true,
   Edge: Edge,
   Node: Node,
   OrbitControls: OrbitControls,

--- a/argo-lite/src/graph-frontend/src/imports.js
+++ b/argo-lite/src/graph-frontend/src/imports.js
@@ -39,7 +39,7 @@ exports.default = {
   LAYOUT: "d3",
   LINES: "notfancy",
   MAP: true,
-  MAP_RENDER_PER_NUMBER_OF_FRAME: 20,
+  MAP_RENDER_PER_NUMBER_OF_FRAME: 10,
   TEXT_SCALE: true,
   TEXT_SIZE: 0.07,
   TEXT_X_OFFSET: 0.52,

--- a/argo-lite/src/graph-frontend/src/imports.js
+++ b/argo-lite/src/graph-frontend/src/imports.js
@@ -1,4 +1,5 @@
 var THREE = require("three");
+var STATS = require("stats.js");
 window.THREE = THREE;
 require("../include/QuickHull");
 require("../include/ConvexGeometry");
@@ -13,6 +14,7 @@ var ee = require("event-emitter");
 
 exports.default = {
   THREE: THREE,
+  STATS: STATS, // stats.js panel for showing fps and other stats.
   Edge: Edge,
   Node: Node,
   OrbitControls: OrbitControls,

--- a/argo-lite/src/graph-frontend/src/imports.js
+++ b/argo-lite/src/graph-frontend/src/imports.js
@@ -15,6 +15,7 @@ var ee = require("event-emitter");
 exports.default = {
   THREE: THREE,
   STATS: STATS, // stats.js panel for showing fps and other stats.
+  STATS_SHOW: false,
   Edge: Edge,
   Node: Node,
   OrbitControls: OrbitControls,

--- a/argo-lite/src/graph-frontend/src/process.js
+++ b/argo-lite/src/graph-frontend/src/process.js
@@ -2,6 +2,7 @@ var def = require("./imports").default;
 const spawn = require("threads").spawn;
 var THREE = def.THREE;
 var STATS = def.STATS;
+var STATS_SHOW = def.STATS_SHOW;
 var Edge = def.Edge;
 var Node = def.Node;
 var OrbitControls = def.OrbitControls;
@@ -69,8 +70,10 @@ var Frame = function(graph, options) {
    */
   let stats = new STATS();
   this.display = function() {
-    stats.showPanel(0); // show fps panel
-    document.body.appendChild(stats.dom);
+    if (STATS_SHOW) {
+      stats.showPanel(0); // show fps panel
+      document.body.appendChild(stats.dom);
+    }
     this.animate();
   };
 
@@ -84,10 +87,17 @@ var Frame = function(graph, options) {
   // let interval = 1000 / fps;
   // let delta;
   this.animate = function() {
-    stats.begin(); // Begin stats.js panel timing
+    if (STATS_SHOW) {
+      stats.begin(); // Begin stats.js panel timing
+    }
+    
     self.controls.update();
     self.render();
-    stats.end(); // End stats.js panel timing
+
+    if (STATS_SHOW) {
+      stats.end(); // End stats.js panel timing
+    }
+    
     // now = Date.now();
     // delta = now - then;
     // if (delta > interval) {

--- a/argo-lite/src/graph-frontend/src/process.js
+++ b/argo-lite/src/graph-frontend/src/process.js
@@ -128,7 +128,7 @@ var Frame = function(graph, options) {
     self.setupSelect();
 
     self.element.appendChild(self.renderer.domElement);
-    // self.element.appendChild(self.cssRenderer.domElement);
+    self.element.appendChild(self.cssRenderer.domElement);
 
     self.canvas = document.querySelector("graph-container");
 
@@ -160,7 +160,7 @@ var Frame = function(graph, options) {
     self.ccamera.updateProjectionMatrix();
 
     self.renderer.setSize(self.width, self.height);
-    // self.cssRenderer.setSize(self.width, self.height);
+    self.cssRenderer.setSize(self.width, self.height);
   };
 
   /**
@@ -210,7 +210,7 @@ var Frame = function(graph, options) {
     self.renderer.setScissor(self.minimap.width, 0, 1 * self.width, 1 * self.height);
     self.renderer.setScissorTest(true);
     self.renderer.render(self.scene, self.ccamera);
-    // self.cssRenderer.render(self.scene, self.ccamera);
+    self.cssRenderer.render(self.scene, self.ccamera);
 
     // Render MiniMap at a lower framerate.
     if (numberOfFrameSinceMiniMapRerender >= this.mapRenderPerNumberOfFrame) {

--- a/argo-lite/src/graph-frontend/src/process.js
+++ b/argo-lite/src/graph-frontend/src/process.js
@@ -43,6 +43,7 @@ var Frame = function(graph, options) {
   this.labelSize = 6;
   this.relativeFontSize = 1;
   this.mapShowing = def.MAP;
+  this.mapRenderPerNumberOfFrame = def.MAP_RENDER_PER_NUMBER_OF_FRAME;
   this.darkMode = true;
   this.lastNode = null;
   this.fakeNodes = [];
@@ -155,6 +156,7 @@ var Frame = function(graph, options) {
    *  Draws graphics
    */
   var stage = 0;
+  var numberOfFrameSinceMiniMapRerender = 1;
   this.render = function() {
     self.updateCamera();
     self.updateNodes();
@@ -164,6 +166,7 @@ var Frame = function(graph, options) {
       stage = 0;
     }
     stage += 1;
+    numberOfFrameSinceMiniMapRerender += 1;
     if (self.options.layout == "d3") {
       if (self.layoutInit == true) {
         var nodes = [];
@@ -197,7 +200,8 @@ var Frame = function(graph, options) {
     self.renderer.setScissorTest(true);
     self.renderer.render(self.scene, self.ccamera);
     // self.cssRenderer.render(self.scene, self.ccamera);
-    if (self.mapShowing) {
+    if (self.mapShowing && numberOfFrameSinceMinimapRerender >= this.mapRenderPerNumberOfFrame) {
+      numberOfFrameSinceMiniMapRerender = 0;
       self.minimap.width = 0.2 * self.height;
       self.minimap.height = 0.2 * self.height;
       self.renderer.setViewport(0, 0, self.minimap.width, self.minimap.height);

--- a/argo-lite/src/graph-frontend/src/process.js
+++ b/argo-lite/src/graph-frontend/src/process.js
@@ -83,7 +83,6 @@ var Frame = function(graph, options) {
   // let interval = 1000 / fps;
   // let delta;
   this.animate = function() {
-    requestAnimationFrame(self.animate);
     stats.begin(); // Begin stats.js panel timing
     self.controls.update();
     self.render();
@@ -95,6 +94,7 @@ var Frame = function(graph, options) {
     //   self.controls.update();
     //   self.render();
     // }
+    requestAnimationFrame(self.animate);
   };
 
   /**
@@ -116,7 +116,7 @@ var Frame = function(graph, options) {
     self.setupSelect();
 
     self.element.appendChild(self.renderer.domElement);
-    self.element.appendChild(self.cssRenderer.domElement);
+    // self.element.appendChild(self.cssRenderer.domElement);
 
     self.canvas = document.querySelector("graph-container");
 
@@ -148,7 +148,7 @@ var Frame = function(graph, options) {
     self.ccamera.updateProjectionMatrix();
 
     self.renderer.setSize(self.width, self.height);
-    self.cssRenderer.setSize(self.width, self.height);
+    // self.cssRenderer.setSize(self.width, self.height);
   };
 
   /**
@@ -196,7 +196,7 @@ var Frame = function(graph, options) {
     self.renderer.setScissor(0, 0, 1 * self.width, 1 * self.height);
     self.renderer.setScissorTest(true);
     self.renderer.render(self.scene, self.ccamera);
-    self.cssRenderer.render(self.scene, self.ccamera);
+    // self.cssRenderer.render(self.scene, self.ccamera);
     if (self.mapShowing) {
       self.minimap.width = 0.2 * self.height;
       self.minimap.height = 0.2 * self.height;

--- a/argo-lite/src/graph-frontend/src/process.js
+++ b/argo-lite/src/graph-frontend/src/process.js
@@ -104,7 +104,8 @@ var Frame = function(graph, options) {
   this.init = function(aa = true) {
     self.renderer = new THREE.WebGLRenderer({
       alpha: true,
-      antialias: aa
+      antialias: aa,
+      preserveDrawingBuffer: true,
     });
     //self.renderer.setPixelRatio(window.devicePixelRatio);
     //self.renderer.setPixelRatio(0.1);
@@ -196,18 +197,23 @@ var Frame = function(graph, options) {
       }
     }
     self.renderer.setViewport(0, 0, 1 * self.width, 1 * self.height);
-    self.renderer.setScissor(0, 0, 1 * self.width, 1 * self.height);
+    self.renderer.setScissor(self.minimap.width, 0, 1 * self.width, 1 * self.height);
     self.renderer.setScissorTest(true);
     self.renderer.render(self.scene, self.ccamera);
     // self.cssRenderer.render(self.scene, self.ccamera);
-    if (self.mapShowing && numberOfFrameSinceMinimapRerender >= this.mapRenderPerNumberOfFrame) {
+
+    // Render MiniMap at a lower framerate.
+    if (numberOfFrameSinceMiniMapRerender >= this.mapRenderPerNumberOfFrame) {
       numberOfFrameSinceMiniMapRerender = 0;
-      self.minimap.width = 0.2 * self.height;
-      self.minimap.height = 0.2 * self.height;
-      self.renderer.setViewport(0, 0, self.minimap.width, self.minimap.height);
-      self.renderer.setScissor(0, 0, self.minimap.width, self.minimap.height);
-      self.renderer.setScissorTest(true);
-      self.renderer.render(self.scene, self.minimap.camera);
+
+      if (self.mapShowing) {
+        self.minimap.width = 0.2 * self.height;
+        self.minimap.height = 0.2 * self.height;
+        self.renderer.setViewport(0, 0, self.minimap.width, self.minimap.height);
+        self.renderer.setScissor(0, 0, self.minimap.width, self.minimap.height);
+        self.renderer.setScissorTest(true);
+        self.renderer.render(self.scene, self.minimap.camera);
+      }
     }
   };
 };

--- a/argo-lite/src/graph-frontend/src/process.js
+++ b/argo-lite/src/graph-frontend/src/process.js
@@ -1,6 +1,7 @@
 var def = require("./imports").default;
 const spawn = require("threads").spawn;
 var THREE = def.THREE;
+var STATS = def.STATS;
 var Edge = def.Edge;
 var Node = def.Node;
 var OrbitControls = def.OrbitControls;
@@ -65,28 +66,35 @@ var Frame = function(graph, options) {
   /**
    *  Starting point, run once to create scene
    */
+  let stats = new STATS();
   this.display = function() {
+    stats.showPanel(0); // show fps panel
+    document.body.appendChild(stats.dom);
     this.animate();
   };
 
   /**
    *  Creates loop called on every animation frame
    */
+  
   let fps = 30;
-  let now;
-  let then = Date.now();
-  let interval = 1000 / fps;
-  let delta;
+  // let now;
+  // let then = Date.now();
+  // let interval = 1000 / fps;
+  // let delta;
   this.animate = function() {
     requestAnimationFrame(self.animate);
-
-    now = Date.now();
-    delta = now - then;
-    if (delta > interval) {
-      then = now;
-      self.controls.update();
-      self.render();
-    }
+    stats.begin(); // Begin stats.js panel timing
+    self.controls.update();
+    self.render();
+    stats.end(); // End stats.js panel timing
+    // now = Date.now();
+    // delta = now - then;
+    // if (delta > interval) {
+    //   then = now;
+    //   self.controls.update();
+    //   self.render();
+    // }
   };
 
   /**

--- a/argo-lite/src/graph-frontend/src/setup.js
+++ b/argo-lite/src/graph-frontend/src/setup.js
@@ -68,10 +68,10 @@ module.exports = function(self) {
 
   self.setRendererParams = function() {
     self.renderer.setSize(self.width, self.height);
-    self.cssRenderer = new THREE.CSS3DRenderer();
-    self.cssRenderer.setSize(self.width, self.height);
-    self.cssRenderer.domElement.style.position = "absolute";
-    self.cssRenderer.domElement.style.top = 0;
+    // self.cssRenderer = new THREE.CSS3DRenderer();
+    // self.cssRenderer.setSize(self.width, self.height);
+    // self.cssRenderer.domElement.style.position = "absolute";
+    // self.cssRenderer.domElement.style.top = 0;
     self.renderer.setPixelRatio(window.devicePixelRatio);
   };
 

--- a/argo-lite/src/graph-frontend/src/setup.js
+++ b/argo-lite/src/graph-frontend/src/setup.js
@@ -68,10 +68,10 @@ module.exports = function(self) {
 
   self.setRendererParams = function() {
     self.renderer.setSize(self.width, self.height);
-    // self.cssRenderer = new THREE.CSS3DRenderer();
-    // self.cssRenderer.setSize(self.width, self.height);
-    // self.cssRenderer.domElement.style.position = "absolute";
-    // self.cssRenderer.domElement.style.top = 0;
+    self.cssRenderer = new THREE.CSS3DRenderer();
+    self.cssRenderer.setSize(self.width, self.height);
+    self.cssRenderer.domElement.style.position = "absolute";
+    self.cssRenderer.domElement.style.top = 0;
     self.renderer.setPixelRatio(window.devicePixelRatio);
   };
 


### PR DESCRIPTION
Ensure that graphs of 1000 nodes have average fps of 30-60.

- Lower refresh rate of minimap, which proves to be an expensive rendering operation the way we implemented it.
- Turns off label rendering when no label is being shown.
  - The labels are rendered by CSSRenderer which is the most expensive renderer.
  - Add API for pausing/resuming the label renderer and removing/adding it from/to DOM
- Add Stats.js debugging panel that can be configured to show in `graph-frontend/imports.js`
